### PR TITLE
Save state in SessionStoreage on login redirect

### DIFF
--- a/src/hooks/useUserInfo.tsx
+++ b/src/hooks/useUserInfo.tsx
@@ -88,6 +88,7 @@ export const useUserInfo = () => {
       const storedStateString = window.sessionStorage.getItem('LOGIN_REDIRECT_STATE');
       if (storedStateString) {
         const storedState = JSON.parse(storedStateString) as IState;
+        window.sessionStorage.removeItem('LOGIN_REDIRECT_STATE');
         dispatch({
           type: ActionType.CHANGE,
           data: storedState,

--- a/src/hooks/useUserInfo.tsx
+++ b/src/hooks/useUserInfo.tsx
@@ -5,7 +5,7 @@ import { AUTH_CALLBACK, AUTH_CLIENT_ID, AUTH_ENDPOINT } from 'constants/auth';
 import { ReceiptContext } from 'contexts/ReceiptData';
 import { getProfile, IProfile } from 'utils/profile';
 
-import { ActionType } from './useReceiptData';
+import { ActionType, IState } from './useReceiptData';
 
 const MANAGER = new UserManager({
   authority: AUTH_ENDPOINT,
@@ -49,7 +49,7 @@ const getEmail = (email: string, profile?: IProfile) => {
 };
 
 export const useUserInfo = () => {
-  const { dispatch } = useContext(ReceiptContext);
+  const { state, dispatch } = useContext(ReceiptContext);
 
   const processUser = async (user: User) => {
     const profile: IAuthProfile = user.profile;
@@ -64,22 +64,35 @@ export const useUserInfo = () => {
     });
   };
 
+  const logInRedirect = () => {
+    window.sessionStorage.setItem('LOGIN_REDIRECT_STATE', JSON.stringify(state));
+    MANAGER.signinRedirect();
+  };
+
   const logIn = async () => {
     try {
       const user: User | null = await MANAGER.getUser();
       if (user) {
         processUser(user);
       } else {
-        MANAGER.signinRedirect();
+        logInRedirect();
       }
     } catch (err) {
-      MANAGER.signinRedirect();
+      logInRedirect();
     }
   };
 
   const catchCallback = async () => {
     try {
       const user = await MANAGER.signinRedirectCallback();
+      const storedStateString = window.sessionStorage.getItem('LOGIN_REDIRECT_STATE');
+      if (storedStateString) {
+        const storedState = JSON.parse(storedStateString) as IState;
+        dispatch({
+          type: ActionType.CHANGE,
+          data: storedState,
+        });
+      }
       processUser(user);
     } catch (err) {
       /** Do nothing if no user data is present */


### PR DESCRIPTION
Save current form state to SessionStorage when the user logs in.

Since the login is done with a redirect, the state of the form is currently discarded if parts of the form is filled out before a user attempts a login.
This fixes it by temporarily saving it, and deleting it afterwards.