### PR TITLE
Fix/validation messages

### DIFF
--- a/src/components/Areas/Bank/AccountField.tsx
+++ b/src/components/Areas/Bank/AccountField.tsx
@@ -1,0 +1,29 @@
+import React, { FC } from 'react';
+
+import { ReceiptTextField } from 'components/Input/ReceiptTextField';
+
+const FORMAT_ACCOUNT_VALUE = (value: string): string => {
+  const chars = value.replace(/\ /g, '').split('');
+  let insertedSpace = '';
+  for (let i = 0; i < chars.length; i++) {
+    if (i >= 11) {
+      break;
+    } else if (i === 4 || i === 6) {
+      insertedSpace += ' ';
+    }
+    const char = chars[i];
+    insertedSpace += char;
+  }
+  return insertedSpace;
+};
+
+export const AccountField: FC = () => {
+  return (
+    <ReceiptTextField
+      field="account"
+      label="Kontonummer"
+      placeholder="Kontonummer for tilbakeføring"
+      format={FORMAT_ACCOUNT_VALUE}
+    />
+  );
+};

--- a/src/components/Areas/Bank/index.tsx
+++ b/src/components/Areas/Bank/index.tsx
@@ -8,6 +8,8 @@ import { ReceiptTextField } from 'components/Input/ReceiptTextField';
 import { ReceiptTypeRadio } from 'components/Input/ReceiptTypeRadio';
 import { ReceiptContext } from 'contexts/ReceiptData';
 
+import { AccountField } from './AccountField';
+
 const RadioFieldSet = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -30,6 +32,7 @@ const ContentFieldSet = styled.div`
 
 export const BankInfo = () => {
   const { state } = useContext(ReceiptContext);
+
   return (
     <>
       <ContentFieldSet>
@@ -45,9 +48,7 @@ export const BankInfo = () => {
         </div>
       </ContentFieldSet>
       <FieldSet>
-        {state.type === 'deposit' && (
-          <ReceiptTextField field="account" label="Kontonummer" placeholder="Kontonummer for tilbakeføring" />
-        )}
+        {state.type === 'deposit' && <AccountField />}
         {state.type === 'card' && (
           <ReceiptTextField
             field="cardDetails"

--- a/src/components/Areas/User/SignatureInput.tsx
+++ b/src/components/Areas/User/SignatureInput.tsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react';
 import { FileInput } from 'components/Input';
 import { ReceiptContext } from 'contexts/ReceiptData';
 import { ActionType } from 'hooks/useReceiptData';
+import { useValidation } from 'hooks/useValidation';
 
 export const SignatureInput = () => {
   const { state, dispatch } = useContext(ReceiptContext);
@@ -25,7 +26,16 @@ export const SignatureInput = () => {
     });
   };
 
+  const { validation, level } = useValidation('signature');
+
   return (
-    <FileInput label="Signatur" onUpload={handleFileChange} onRemove={removeFile} file={state.signature || undefined} />
+    <FileInput
+      label="Signatur"
+      onUpload={handleFileChange}
+      onRemove={removeFile}
+      file={state.signature || undefined}
+      validation={validation}
+      validationLevel={level}
+    />
   );
 };

--- a/src/components/Input/Base.tsx
+++ b/src/components/Input/Base.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components';
 
 import { colors } from 'constants/colors';
 import { IValidation, ValidationLevel } from 'form/validation';
+import { getValidationLevelColor, IValidationMessageProps, ValidationMessages } from './ValidationMessages';
 
 export const BaseInputStyle = css`
   width: 100%;
@@ -29,6 +30,8 @@ export const StyledInput = React.memo(styled.input<IValidationMessageProps>`
   ${BaseInputStyle}
   ${({ level }) => level && `border-color: ${getValidationLevelColor(level)};`}
 
+  ${({ highlight }) => highlight && `border-color: ${colors.blue};`}
+
   :focus {
     ${({ level }) => level && `border-color: ${getValidationLevelColor(level)};`}
   }
@@ -54,34 +57,12 @@ export const InputContainer = React.memo(styled.div`
   flex-direction: column;
 `);
 
-export interface IValidationMessageProps {
-  level?: ValidationLevel;
-}
-
-export const getValidationLevelColor = (level?: ValidationLevel) => {
-  switch (level) {
-    default:
-      return colors.darkGray;
-    case ValidationLevel.NONE:
-      return colors.darkGray;
-    case ValidationLevel.WARNING:
-      return colors.orange;
-    case ValidationLevel.REQUIRED:
-      return colors.red;
-  }
-};
-
-export const ValidationMessage = React.memo(styled.p<IValidationMessageProps>`
-  color: ${({ level }) => getValidationLevelColor(level)};
-  margin: 0 0 4px 0;
-  transition: opacity 1s linear;
-`);
-
 export interface IInputProps extends HTMLProps<HTMLInputElement> {
   label: string;
   type?: string;
   validation?: IValidation[];
   validationLevel?: ValidationLevel;
+  highlight?: boolean;
 }
 
 export const Input: FC<IInputProps> = React.memo(
@@ -100,12 +81,7 @@ export const Input: FC<IInputProps> = React.memo(
     return (
       <InputContainer>
         <Label>{label}</Label>
-        {interacted &&
-          validation.map(({ level, message }) => (
-            <ValidationMessage key={message} level={level}>
-              {message}
-            </ValidationMessage>
-          ))}
+        <ValidationMessages display={interacted} validation={validation} />
         <StyledInput {...props} onBlur={showValidation} level={interacted ? validationLevel : undefined} />
       </InputContainer>
     );

--- a/src/components/Input/CommitteeDropdown.tsx
+++ b/src/components/Input/CommitteeDropdown.tsx
@@ -11,7 +11,10 @@ import { Select } from './Dropdown';
 const Option = styled.option``;
 
 const SelectContainer = styled.div`
-  margin: auto 0;
+  display: flex;
+  margin: 0.8rem 0;
+  flex-direction: column;
+  justify-content: flex-end;
 `;
 
 export const CommitteeDropdown: FC = () => {

--- a/src/components/Input/FakeInput.tsx
+++ b/src/components/Input/FakeInput.tsx
@@ -2,16 +2,20 @@ import styled from 'styled-components';
 
 import { colors } from 'constants/colors';
 
-export const FakeInput = styled.div`
-  width: 100%;
+import { BaseInputStyle } from './Base';
+import { getValidationLevelColor, IValidationMessageProps } from './ValidationMessages';
 
-  background: ${colors.white};
-  border-radius: 5px;
-  border: 2px solid ${colors.gray};
-
-  padding: 0.6rem;
-  box-sizing: border-box;
+export const FakeInput = styled.div<IValidationMessageProps>`
+  ${BaseInputStyle}
 
   display: grid;
   justify-content: center;
+
+  ${({ level }) => level && `border-color: ${getValidationLevelColor(level)};`}
+
+  ${({ highlight }) => highlight && `border-color: ${colors.blue};`}
+
+  :focus {
+    ${({ level }) => level && `border-color: ${getValidationLevelColor(level)};`}
+  }
 `;

--- a/src/components/Input/FileDisplay.tsx
+++ b/src/components/Input/FileDisplay.tsx
@@ -5,6 +5,7 @@ import { FakeInput } from './FakeInput';
 import { FileImage } from './FileImage';
 
 import { colors } from 'constants/colors';
+import { ValidationLevel } from 'form/validation';
 
 const FileName = styled.p`
   color: ${colors.darkGray};
@@ -13,8 +14,9 @@ const FileName = styled.p`
 export interface IFileDisplayProps {
   file: File;
   image: string | null;
+  level?: ValidationLevel;
 }
 
-export const FileDisplay: FC<IFileDisplayProps> = ({ file, image }) => {
-  return <FakeInput>{image ? <FileImage src={image} /> : <FileName>{file.name}</FileName>}</FakeInput>;
+export const FileDisplay: FC<IFileDisplayProps> = ({ file, image, level }) => {
+  return <FakeInput level={level}>{image ? <FileImage src={image} /> : <FileName>{file.name}</FileName>}</FakeInput>;
 };

--- a/src/components/Input/FileInput.tsx
+++ b/src/components/Input/FileInput.tsx
@@ -1,11 +1,13 @@
 import React, { ChangeEvent, FC, useEffect, useRef, useState } from 'react';
 
+import { ValidationLevel } from 'form/validation';
 import { readFileAsDataUrl } from 'utils/readFileAsDataUrl';
 
 import { IInputProps, InputContainer, StyledInput } from './Base';
 import { FileDisplay } from './FileDisplay';
 import { FileInfo } from './FileInfo';
 import { FileLabels } from './FileLabels';
+import { ValidationMessages } from './ValidationMessages';
 
 const IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/svg+xml', 'image/jpg'];
 const ALLOWED_TYPES = [...IMAGE_TYPES, 'application/pdf', '.pdf'];

--- a/src/components/Input/FileInput.tsx
+++ b/src/components/Input/FileInput.tsx
@@ -18,9 +18,22 @@ export interface IFileInputProps extends IInputProps {
   onRemove?: () => void;
 }
 
-export const FileInput: FC<IFileInputProps> = ({ label, file, onRemove, onUpload, ...props }) => {
+export const FileInput: FC<IFileInputProps> = ({
+  label,
+  file,
+  onRemove,
+  onUpload,
+  validation = [],
+  validationLevel = ValidationLevel.NONE,
+  ...props
+}) => {
   const [image, setImage] = useState<null | string>(null);
+  const [fileHover, setFileHover] = useState(false);
+  const [interacted, setInteracted] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const onFileHover = () => setFileHover(true);
+  const onCancelFileHover = () => setFileHover(false);
 
   const readImageFile = async (dataFile: File) => {
     const newImage = await readFileAsDataUrl(dataFile);
@@ -55,21 +68,28 @@ export const FileInput: FC<IFileInputProps> = ({ label, file, onRemove, onUpload
       onUpload(files[0]);
     }
     clearInputValue();
+    onCancelFileHover();
   };
 
   return (
     <InputContainer>
       <FileLabels label={label} onCrossClick={clearFile} displayCross={!!file} />
+      <ValidationMessages display={interacted} validation={validation} />
       {file ? (
-        <FileDisplay file={file} image={image} />
+        <FileDisplay file={file} image={image} level={validationLevel} />
       ) : (
         <StyledInput
           type="file"
+          onDragEnter={onFileHover}
+          onDragLeave={onCancelFileHover}
+          highlight={fileHover}
           value={props.value}
           onChange={handleUpload}
           placeholder={props.placeholder}
           ref={fileInputRef}
           accept={ALLOWED_TYPES.join(',')}
+          level={interacted ? validationLevel : undefined}
+          onBlur={() => setInteracted(true)}
         />
       )}
       <FileInfo file={file} />

--- a/src/components/Input/ReceiptTextField.tsx
+++ b/src/components/Input/ReceiptTextField.tsx
@@ -12,16 +12,18 @@ export interface IProps {
   label: string;
   disabled?: boolean;
   placeholder?: string;
+  format?: (value: string) => string;
 }
 
-export const ReceiptTextField: FC<IProps> = ({ field, ...props }) => {
+export const ReceiptTextField: FC<IProps> = ({ field, format, ...props }) => {
   const { state, dispatch } = useContext(ReceiptContext);
 
   const change = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const val = format ? format(event.target.value) : event.target.value;
     dispatch({
       type: ActionType.CHANGE,
       data: {
-        [field]: event.target.value,
+        [field]: val,
       },
     });
   };

--- a/src/components/Input/TextArea.tsx
+++ b/src/components/Input/TextArea.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 
 import { IValidation, ValidationLevel } from 'form/validation';
 
-import { BaseInputStyle, getValidationLevelColor, InputContainer, Label, ValidationMessage } from './Base';
+import { BaseInputStyle, InputContainer, Label } from './Base';
+import { getValidationLevelColor, ValidationMessages } from './ValidationMessages';
 
 export interface ITextAreaProps extends HTMLProps<HTMLTextAreaElement> {
   label: string;
@@ -45,12 +46,7 @@ export const TextArea: FC<ITextAreaProps> = ({
   return (
     <InputContainer>
       <Label>{label}</Label>
-      {interacted &&
-        validation.map(({ level, message }) => (
-          <ValidationMessage key={message} level={level}>
-            {message}
-          </ValidationMessage>
-        ))}
+      <ValidationMessages display={interacted} validation={validation} />
       <MultilineInput
         value={props.value}
         onChange={props.onChange}

--- a/src/components/Input/ValidationMessages.tsx
+++ b/src/components/Input/ValidationMessages.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from 'react';
+import styled from 'styled-components';
+
+import { colors } from 'constants/colors';
+import { IValidation, ValidationLevel } from 'form/validation';
+
+export interface IValidationMessageProps {
+  level?: ValidationLevel;
+  highlight?: boolean;
+}
+
+export const getValidationLevelColor = (level?: ValidationLevel) => {
+  switch (level) {
+    default:
+      return colors.darkGray;
+    case ValidationLevel.NONE:
+      return colors.darkGray;
+    case ValidationLevel.WARNING:
+      return colors.orange;
+    case ValidationLevel.REQUIRED:
+      return colors.red;
+    case ValidationLevel.VALID:
+      return colors.green;
+  }
+};
+
+export const ValidationMessage = React.memo(styled.p<IValidationMessageProps>`
+  color: ${({ level }) => getValidationLevelColor(level)};
+  margin: 0 0 4px 0;
+  transition: opacity 1s linear;
+`);
+
+export interface IProps {
+  display: boolean;
+  validation: IValidation[];
+}
+
+export const ValidationMessages: FC<IProps> = ({ display, validation }) => {
+  return (
+    <>
+      {display &&
+        validation.map(({ level, message }) => (
+          <ValidationMessage key={message} level={level}>
+            {message}
+          </ValidationMessage>
+        ))}{' '}
+    </>
+  );
+};

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -8,5 +8,6 @@ export const colors = {
   blue: '#0060a3',
   orange: '#faa21b',
   red: '#eb536e',
+  green: '#43b171',
   white: '#ffffff',
 };

--- a/src/form/validation.ts
+++ b/src/form/validation.ts
@@ -6,6 +6,7 @@ export enum ValidationLevel {
   NONE,
   WARNING,
   REQUIRED,
+  VALID,
 }
 
 export interface IValidator {

--- a/src/form/validation.ts
+++ b/src/form/validation.ts
@@ -25,7 +25,7 @@ export type StateValidation = { [K in keyof IState]: IValidation[] };
 
 export type StateValidators = { [K in keyof IState]: IValidator[] };
 
-const ACCOUNT_NUMBER_REGEX = new RegExp(/^\d{11}$/);
+const ACCOUNT_NUMBER_REGEX = new RegExp(/^\d{4}\ \d{2}\ \d{5}$/);
 const COMMITTEE_EMAIL_REGEX = new RegExp(/^.{2,50}@online\.ntnu\.no$/);
 const EMAIL_REGEX = new RegExp(/^[a-zA-Z0-9.!#$%&’*+/=?^_{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/);
 const CARD_DETAIL_REGEX = new RegExp(/^.{5,30}$/);

--- a/src/hooks/useValidation.tsx
+++ b/src/hooks/useValidation.tsx
@@ -14,5 +14,5 @@ export const useValidation = (field: keyof IState) => {
     ValidationLevel.NONE
   );
 
-  return { validation, level };
+  return { validation, level: validation.length ? level : ValidationLevel.VALID };
 };


### PR DESCRIPTION
- Add validation level and color for 'VALID' fields. Making them appear green
- Make sure dropdown components formats the same way as other fields when messages are applied.
- Add validation level display and messages to 'signature'
- Auto add format with spacing for 'account', force `/\d{4}\ \d{2}\ \d{4}` format