### PR TITLE
Persist state on login redirect

### DIFF
--- a/src/components/Areas/Extra/FileSize.tsx
+++ b/src/components/Areas/Extra/FileSize.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { colors } from 'constants/colors';
 import { ReceiptContext } from 'contexts/ReceiptData';
 import { formatBytes } from 'utils/bytes';
+import { getTotalFileSize } from 'utils/getTotalFileSize';
 
 const StatusContainer = styled.div`
   display: flex;
@@ -23,10 +24,7 @@ const MAX_SIZE = 19 * 1024 * 1024; // 19 MB
 
 export const FileSize = () => {
   const { state } = useContext(ReceiptContext);
-
-  const signatureSize = state.signature ? state.signature.size : 0;
-  const attachmentsSize = state.attachments.map((file) => file.size).reduce((size, total) => total + size, 0);
-  const totalSize = signatureSize + attachmentsSize;
+  const totalSize = getTotalFileSize(state);
   const sizeText = formatBytes(totalSize);
 
   return (

--- a/src/components/Signature/index.tsx
+++ b/src/components/Signature/index.tsx
@@ -64,7 +64,9 @@ export const Signature: FC<IProps> = ({ saveClick, editClick }) => {
     if (signaturePad) {
       const imageURL = signaturePad.toDataURL('image/png');
       const image = await readDataUrlAsFile(imageURL);
-      saveClick(image);
+      if (image) {
+        saveClick(image);
+      }
       editClick();
     }
   };

--- a/src/form/state.ts
+++ b/src/form/state.ts
@@ -68,7 +68,7 @@ export const serializeReceipt = async (deserializedState: IDeserializedState): P
   const signature = await readDataUrlAsFile(deserializedState.signature);
   return {
     ...deserializedState,
-    attachments,
+    attachments: attachments.filter(Boolean) as File[],
     signature,
   };
 };

--- a/src/hooks/useUserInfo.tsx
+++ b/src/hooks/useUserInfo.tsx
@@ -109,6 +109,8 @@ export const useUserInfo = () => {
         const newState = await processUser(user, state);
         change(newState);
       }
+      /** Purge all OIDC user data from URL */
+      window.location.hash = '';
     } catch (err) {
       /** Do nothing if no user data is present */
       return;

--- a/src/utils/getTotalFileSize.ts
+++ b/src/utils/getTotalFileSize.ts
@@ -1,0 +1,8 @@
+import { IState } from 'form/state';
+
+export const getTotalFileSize = (state: IState) => {
+  const signatureSize = state.signature ? state.signature.size : 0;
+  const attachmentsSize = state.attachments.map((file) => file.size).reduce((size, total) => total + size, 0);
+  const totalSize = signatureSize + attachmentsSize;
+  return totalSize;
+};

--- a/src/utils/readDataUrlAsFile.ts
+++ b/src/utils/readDataUrlAsFile.ts
@@ -4,23 +4,23 @@ export const generateRandomFileName = () => {
     .substring(2);
 };
 
-export const getDataUrlMimeType = (dataUrl: string) => {
+export const getDataUrlMimeType = (dataUrl: string): string | null => {
   const [info] = dataUrl.split(',');
   const matches = info.match(/[^:\s*]\w+\/[\w-+\d.]+(?=[;| ])/);
   const type = matches ? matches[0] : null;
-  if (!type) {
-    throw new Error('Expected File as a dataUrl, could not extract mime-type information');
-  }
   return type;
 };
 
 export const readDataUrlAsFile = async (dataUrl: string, fileName?: string) => {
   try {
     const type = getDataUrlMimeType(dataUrl);
-    const res = await fetch(dataUrl);
-    const buffer = await res.arrayBuffer();
-    const file = new File([buffer], fileName || generateRandomFileName(), { type });
-    return file;
+    if (type) {
+      const res = await fetch(dataUrl);
+      const buffer = await res.arrayBuffer();
+      const file = new File([buffer], fileName || generateRandomFileName(), { type });
+      return file;
+    }
+    return null;
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
- Temporarily store form data in SessionStorage when the user logs in via OIDC. Only if files are below 4 MB in total size.
- Ensure correct behavior when the string provided to decode to a File is not valid.
- Purge OIDC user data from URL after login is complete.

fixes #25 