### PR TITLE
Move interaction to context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
 
+import { Interaction } from 'contexts/Interaction';
 import { ReceiptData } from 'contexts/ReceiptData';
 import { Footer } from './components/Footer';
 import { Header } from './components/Header';
@@ -13,7 +14,11 @@ const AppStyle = styled.div`
 `;
 
 const Contexts: FC = ({ children }) => {
-  return <ReceiptData>{children}</ReceiptData>;
+  return (
+    <Interaction>
+      <ReceiptData>{children}</ReceiptData>
+    </Interaction>
+  );
 };
 
 export const App = () => {

--- a/src/components/Areas/Extra/index.tsx
+++ b/src/components/Areas/Extra/index.tsx
@@ -1,11 +1,14 @@
 import React, { useContext } from 'react';
+import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 
 import { Button } from 'components/Button';
 import { SeparatedFieldSet } from 'components/FieldSet';
 import { ReceiptTextArea } from 'components/Input/ReceiptTextArea';
 import { colors } from 'constants/colors';
+import { InteractionContext } from 'contexts/Interaction';
 import { ReceiptContext } from 'contexts/ReceiptData';
+import { INITIAL_INTERACTION } from 'form/interaction';
 import { ValidationLevel } from 'form/validation';
 import { ActionType } from 'hooks/useReceiptData';
 
@@ -26,15 +29,26 @@ const WarningMessage = styled.h3`
   color: ${colors.red};
 `;
 
+const interactAll = () => {
+  return Object.keys(INITIAL_INTERACTION).reduce((acc, key) => ({ ...acc, [key]: true }), INITIAL_INTERACTION);
+};
+
 export const ExtraInfo = () => {
   const { dispatch, validation } = useContext(ReceiptContext);
+  const { updateInteraction } = useContext(InteractionContext);
 
   const send = () => {
-    dispatch({ type: ActionType.SEND, data: undefined });
+    ReactDOM.unstable_batchedUpdates(() => {
+      dispatch({ type: ActionType.SEND, data: undefined });
+      updateInteraction(interactAll());
+    });
   };
 
   const download = () => {
-    dispatch({ type: ActionType.DOWNLOAD, data: undefined });
+    ReactDOM.unstable_batchedUpdates(() => {
+      dispatch({ type: ActionType.DOWNLOAD, data: undefined });
+      updateInteraction(interactAll());
+    });
   };
   const errors = Object.values(validation)
     .flat()

--- a/src/components/Areas/User/SignatureInput.tsx
+++ b/src/components/Areas/User/SignatureInput.tsx
@@ -3,6 +3,7 @@ import React, { FC, useContext } from 'react';
 import { Edit } from 'components/Icons/Edit';
 import { FileInput } from 'components/Input';
 import { ReceiptContext } from 'contexts/ReceiptData';
+import { useInteraction } from 'hooks/useInteraction';
 import { ActionType } from 'hooks/useReceiptData';
 import { useValidation } from 'hooks/useValidation';
 
@@ -32,6 +33,7 @@ export const SignatureInput: FC<IProps> = ({ editClick }) => {
   };
 
   const { validation, level } = useValidation('signature');
+  const { interacted, setInteracted } = useInteraction('signature');
 
   return (
     <FileInput
@@ -43,6 +45,8 @@ export const SignatureInput: FC<IProps> = ({ editClick }) => {
       validationLevel={level}
       buttons={<Edit onClick={editClick} title="Tegn signatur" />}
       placeholder="Trykk på pennen for å skrive inn signatur. Klikk på dette feltet, eller dra en fil hit for å laste opp"
+      interacted={interacted}
+      onBlur={setInteracted}
     />
   );
 };

--- a/src/components/Input/Base.tsx
+++ b/src/components/Input/Base.tsx
@@ -1,4 +1,4 @@
-import React, { FC, HTMLProps, useState } from 'react';
+import React, { FC, HTMLProps } from 'react';
 import styled, { css } from 'styled-components';
 
 import { colors } from 'constants/colors';
@@ -75,21 +75,11 @@ export const Input: FC<IInputProps> = React.memo(
     /** Extract 'ref' and 'as' from props as styled-components types mismatch with React */
     const { ref, as, ...props } = rest;
 
-    const [fieldInteracted, setInteracted] = useState(false);
-
-    const showValidation = () => {
-      if (props.value !== props.defaultValue) {
-        setInteracted(true);
-      }
-    };
-
-    const isInteracted = interacted || fieldInteracted;
-
     return (
       <InputContainer>
         <Label>{label}</Label>
-        <ValidationMessages display={isInteracted} validation={validation} />
-        <StyledInput {...props} onBlur={showValidation} level={isInteracted ? validationLevel : undefined} />
+        <ValidationMessages display={Boolean(interacted)} validation={validation} />
+        <StyledInput {...props} level={interacted ? validationLevel : undefined} />
       </InputContainer>
     );
   }

--- a/src/components/Input/FileInput.tsx
+++ b/src/components/Input/FileInput.tsx
@@ -31,12 +31,13 @@ export const FileInput: FC<IFileInputProps> = ({
   validation = [],
   validationLevel = ValidationLevel.NONE,
   buttons,
-  placeholder,
+  interacted,
+  ref,
+  as,
   ...props
 }) => {
   const [image, setImage] = useState<null | string>(null);
   const [fileHover, setFileHover] = useState(false);
-  const [interacted, setInteracted] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const onFileHover = () => setFileHover(true);
@@ -95,7 +96,7 @@ export const FileInput: FC<IFileInputProps> = ({
           </>
         )}
       </FileLabels>
-      <ValidationMessages display={interacted} validation={validation} />
+      <ValidationMessages display={Boolean(interacted)} validation={validation} />
       {file ? (
         <FileDisplay file={file} image={image} level={validationLevel} />
       ) : (
@@ -103,14 +104,12 @@ export const FileInput: FC<IFileInputProps> = ({
           type="file"
           onDragEnter={onFileHover}
           onDragLeave={onCancelFileHover}
-          value={props.value}
           onChange={handleUpload}
           inputRef={fileInputRef}
           accept={ALLOWED_TYPES.join(',')}
-          onBlur={() => setInteracted(true)}
           level={interacted ? validationLevel : undefined}
           highlight={fileHover}
-          placeholder={placeholder}
+          {...props}
         />
       )}
       <FileInfo file={file} />

--- a/src/components/Input/ReceiptNumberField.tsx
+++ b/src/components/Input/ReceiptNumberField.tsx
@@ -2,6 +2,7 @@ import React, { FC, useContext } from 'react';
 
 import { ReceiptContext } from 'contexts/ReceiptData';
 import { IState } from 'form/state';
+import { useInteraction } from 'hooks/useInteraction';
 import { ActionType } from 'hooks/useReceiptData';
 import { useValidation } from 'hooks/useValidation';
 
@@ -31,6 +32,7 @@ export const ReceiptNumberField: FC<IProps> = ({ field, ...props }) => {
   }
 
   const { validation, level } = useValidation(field);
+  const { interacted, setInteracted } = useInteraction(field);
 
   return (
     <Input
@@ -39,6 +41,8 @@ export const ReceiptNumberField: FC<IProps> = ({ field, ...props }) => {
       onChange={change}
       validation={validation}
       validationLevel={level}
+      interacted={interacted}
+      onBlur={setInteracted}
       {...props}
     />
   );

--- a/src/components/Input/ReceiptTextArea.tsx
+++ b/src/components/Input/ReceiptTextArea.tsx
@@ -2,6 +2,7 @@ import React, { FC, useContext } from 'react';
 
 import { ReceiptContext } from 'contexts/ReceiptData';
 import { IState } from 'form/state';
+import { useInteraction } from 'hooks/useInteraction';
 import { ActionType } from 'hooks/useReceiptData';
 import { useValidation } from 'hooks/useValidation';
 
@@ -32,6 +33,17 @@ export const ReceiptTextArea: FC<IProps> = ({ field, ...props }) => {
   }
 
   const { validation, level } = useValidation(field);
+  const { interacted, setInteracted } = useInteraction(field);
 
-  return <TextArea value={value} onChange={change} {...props} validation={validation} validationLevel={level} />;
+  return (
+    <TextArea
+      value={value}
+      onChange={change}
+      {...props}
+      validation={validation}
+      validationLevel={level}
+      onBlur={setInteracted}
+      interacted={interacted}
+    />
+  );
 };

--- a/src/components/Input/ReceiptTextField.tsx
+++ b/src/components/Input/ReceiptTextField.tsx
@@ -2,6 +2,7 @@ import React, { FC, useContext } from 'react';
 
 import { ReceiptContext } from 'contexts/ReceiptData';
 import { IState } from 'form/state';
+import { useInteraction } from 'hooks/useInteraction';
 import { ActionType } from 'hooks/useReceiptData';
 import { useValidation } from 'hooks/useValidation';
 
@@ -34,6 +35,17 @@ export const ReceiptTextField: FC<IProps> = ({ field, format, ...props }) => {
   }
 
   const { validation, level } = useValidation(field);
+  const { interacted, setInteracted } = useInteraction(field);
 
-  return <Input value={value} onChange={change} {...props} validation={validation} validationLevel={level} />;
+  return (
+    <Input
+      value={value}
+      onChange={change}
+      {...props}
+      validation={validation}
+      validationLevel={level}
+      onBlur={setInteracted}
+      interacted={interacted}
+    />
+  );
 };

--- a/src/components/Input/TextArea.tsx
+++ b/src/components/Input/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { FC, HTMLProps, useState } from 'react';
+import React, { FC, HTMLProps } from 'react';
 import styled from 'styled-components';
 
 import { IValidation, ValidationLevel } from 'form/validation';
@@ -10,6 +10,7 @@ export interface ITextAreaProps extends HTMLProps<HTMLTextAreaElement> {
   label: string;
   validation?: IValidation[];
   validationLevel?: ValidationLevel;
+  interacted?: boolean;
 }
 
 export interface IMultiLineInputProps {
@@ -34,27 +35,16 @@ export const TextArea: FC<ITextAreaProps> = ({
   label,
   validationLevel = ValidationLevel.NONE,
   validation = [],
+  interacted,
+  ref,
+  as,
   ...props
 }) => {
-  const [interacted, setInteracted] = useState(false);
-
-  const showValidation = () => {
-    if (props.value !== props.defaultValue) {
-      setInteracted(true);
-    }
-  };
-
   return (
     <InputContainer>
       <Label>{label}</Label>
-      <ValidationMessages display={interacted} validation={validation} />
-      <MultilineInput
-        value={props.value}
-        onChange={props.onChange}
-        placeholder={props.placeholder}
-        level={interacted ? validationLevel : undefined}
-        onBlur={showValidation}
-      />
+      <ValidationMessages display={Boolean(interacted)} validation={validation} />
+      <MultilineInput level={interacted ? validationLevel : undefined} {...props} />
     </InputContainer>
   );
 };

--- a/src/contexts/Interaction.tsx
+++ b/src/contexts/Interaction.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, FC, useState } from 'react';
+
+import { FieldInteractions, INITIAL_INTERACTION } from 'form/interaction';
+
+const MOCK_FUNCTION = () => {
+  throw new Error('Mock Function called from Interaction Context');
+};
+
+export const INITIAL_STATE = {
+  interaction: {} as FieldInteractions,
+  updateInteraction: MOCK_FUNCTION as (updated: Partial<FieldInteractions>) => void,
+  setInteracted: MOCK_FUNCTION as (field: keyof FieldInteractions) => void,
+};
+
+export const InteractionContext = createContext(INITIAL_STATE);
+
+export const Interaction: FC = ({ children }) => {
+  const [interaction, setInteraction] = useState(INITIAL_INTERACTION);
+
+  const updateInteraction = (updated: Partial<FieldInteractions>) => {
+    setInteraction((current) => ({ ...current, ...updated }));
+  };
+
+  const setInteracted = (field: keyof FieldInteractions) => {
+    setInteraction((current) => ({ ...current, [field]: true }));
+  };
+
+  return (
+    <InteractionContext.Provider value={{ interaction, updateInteraction, setInteracted }}>
+      {children}
+    </InteractionContext.Provider>
+  );
+};

--- a/src/form/interaction.ts
+++ b/src/form/interaction.ts
@@ -1,0 +1,9 @@
+import { INITIAL_STATE, IState } from './state';
+
+/** Track if a field has been interacted with by the user */
+export type FieldInteractions = { [K in keyof IState]: boolean };
+
+export const INITIAL_INTERACTION = Object.keys(INITIAL_STATE).reduce(
+  (acc, key) => ({ ...acc, [key]: false }),
+  {} as FieldInteractions
+);

--- a/src/hooks/useInteraction.tsx
+++ b/src/hooks/useInteraction.tsx
@@ -1,0 +1,11 @@
+import { useContext, useMemo } from 'react';
+
+import { InteractionContext } from 'contexts/Interaction';
+import { FieldInteractions } from 'form/interaction';
+
+export const useInteraction = (field: keyof FieldInteractions) => {
+  const { setInteracted: set, interaction, ...rest } = useContext(InteractionContext);
+  const setInteracted = () => set(field);
+  const interacted = interaction[field];
+  return useMemo(() => ({ ...rest, interacted, setInteracted }), [field, interaction]);
+};


### PR DESCRIPTION
Fixes #27 

Makes sure interactions are persisted when user logs in.
Also makes it possible to show validation for a field programmatically.

For example show validation for all fields if the send or download button is clicked.
This can more easily tell the user what fields they are missing or have wrong