### PR TITLE
touchups to validation and formatting

### DIFF
--- a/src/components/Areas/Attachments/FileSize.tsx
+++ b/src/components/Areas/Attachments/FileSize.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { colors } from 'constants/colors';
 import { ReceiptContext } from 'contexts/ReceiptData';
+import { FILE_SIZE_MAX, FILE_SIZE_WARN } from 'form/validation';
 import { formatBytes } from 'utils/bytes';
 import { getTotalFileSize } from 'utils/getTotalFileSize';
 
@@ -17,20 +18,27 @@ const StatusText = styled.h3`
 `;
 
 const WarningText = styled(StatusText)`
-  color: ${colors.red};
+  color: ${colors.orange};
 `;
 
-const MAX_SIZE = 19 * 1024 * 1024; // 19 MB
+const ErrorText = styled(StatusText)`
+  color: ${colors.red};
+`;
 
 export const FileSize = () => {
   const { state } = useContext(ReceiptContext);
   const totalSize = getTotalFileSize(state);
   const sizeText = formatBytes(totalSize);
+  const sizeTextMax = formatBytes(FILE_SIZE_MAX);
 
   return (
     <StatusContainer>
-      {totalSize >= MAX_SIZE ? (
-        <WarningText>{`Opplastede filer overgår tillat størrelse: ${sizeText} / ${formatBytes(MAX_SIZE)}`}</WarningText>
+      {totalSize >= FILE_SIZE_WARN ? (
+        totalSize >= FILE_SIZE_MAX ? (
+          <ErrorText>{`Opplastede filer overgår tillat størrelse: ${sizeText} / ${sizeTextMax}`}</ErrorText>
+        ) : (
+          <WarningText>{`Total størrelse på opplastede filer nærmer seg begrensningen: ${sizeText} / ${sizeTextMax}`}</WarningText>
+        )
       ) : null}
     </StatusContainer>
   );

--- a/src/form/validation.ts
+++ b/src/form/validation.ts
@@ -25,12 +25,12 @@ export type StateValidation = { [K in keyof IState]: IValidation[] };
 
 export type StateValidators = { [K in keyof IState]: IValidator[] };
 
-const ACCOUNT_NUMBER_REGEX = new RegExp(/^\d{4}\ \d{2}\ \d{5}$/);
-const COMMITTEE_EMAIL_REGEX = new RegExp(/^.{2,50}@online\.ntnu\.no$/);
-const EMAIL_REGEX = new RegExp(/^[a-zA-Z0-9.!#$%&’*+/=?^_{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/);
-const CARD_DETAIL_REGEX = new RegExp(/^.{5,30}$/);
-const FILE_SIZE_WARN = 10 * 1024 * 1024; // 10 MB
-const FILE_SIZE_MAX = 18.9 * 1024 * 1024; // 18.9 MB
+export const ACCOUNT_NUMBER_REGEX = new RegExp(/^\d{4}\ \d{2}\ \d{5}$/);
+export const COMMITTEE_EMAIL_REGEX = new RegExp(/^.{2,50}@online\.ntnu\.no$/);
+export const EMAIL_REGEX = new RegExp(/^[a-zA-Z0-9.!#$%&’*+/=?^_{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/);
+export const CARD_DETAIL_REGEX = new RegExp(/^.{5,30}$/);
+export const FILE_SIZE_WARN = 7 * 1024 * 1024; // 7 MB
+export const FILE_SIZE_MAX = 9 * 1024 * 1024; // 9 MB
 
 export const STATE_VALIDATION: StateValidators = {
   fullname: [

--- a/src/form/validation.ts
+++ b/src/form/validation.ts
@@ -1,4 +1,5 @@
 import { COMMITTEES } from 'models/comittees';
+import { formatBytes } from 'utils/bytes';
 
 import { IState } from './state';
 
@@ -110,12 +111,12 @@ export const STATE_VALIDATION: StateValidators = {
     },
     {
       level: ValidationLevel.WARNING,
-      message: 'Det er ikke anbefalt å legge ved filer på over 10 MB',
+      message: `Det er ikke anbefalt å legge ved filer på over ${formatBytes(FILE_SIZE_WARN)}`,
       validator: ({ signature }) => (signature !== null ? signature.size <= FILE_SIZE_WARN : true),
     },
     {
       level: ValidationLevel.REQUIRED,
-      message: 'Det er ikke mulig å legge ved enkeltfiler på over 18.9 MB',
+      message: `Det er ikke tillat å legge ved filer på over ${formatBytes(FILE_SIZE_MAX)}`,
       validator: ({ signature }) => (signature !== null ? signature.size <= FILE_SIZE_MAX : true),
     },
   ],
@@ -127,13 +128,16 @@ export const STATE_VALIDATION: StateValidators = {
     },
     {
       level: ValidationLevel.WARNING,
-      message: 'Det er ikke anbefalt å legge ved filer på over 10 MB',
-      validator: ({ attachments }) => attachments.reduce<number>((total, a) => total + a.size, 0) <= FILE_SIZE_WARN,
+      message: `Det er ikke anbefalt å legge ved filer på over ${formatBytes(FILE_SIZE_WARN)}`,
+      validator: ({ attachments, signature }) =>
+        attachments.reduce<number>((total, a) => total + a.size, 0) + (signature ? signature.size : 0) <=
+        FILE_SIZE_WARN,
     },
     {
       level: ValidationLevel.REQUIRED,
-      message: 'Det er ikke mulig å legge ved filer på over 18.9 MB',
-      validator: ({ attachments }) => attachments.reduce<number>((total, a) => total + a.size, 0) <= FILE_SIZE_MAX,
+      message: `Det er ikke tillat å legge ved filer på over ${formatBytes(FILE_SIZE_MAX)}`,
+      validator: ({ attachments, signature }) =>
+        attachments.reduce<number>((total, a) => total + a.size, 0) + (signature ? signature.size : 0) <= FILE_SIZE_MAX,
     },
   ],
   mode: [

--- a/src/lambda/sendEmail.ts
+++ b/src/lambda/sendEmail.ts
@@ -60,10 +60,10 @@ const createTransporter = async (): Promise<null | ReturnType<typeof nodemailer.
   }
 };
 
-const getformattedText = (form: NonNullableState) => `
+const getFormattedText = (form: NonNullableState) => `
 Type: [${form.type === 'card' ? 'Bankkort' : 'Utlegg'}]
 
-${form.fullname} har sendt inn skjema på ${form.amount} for:
+${form.fullname} har sendt inn skjema på ${form.amount} kr for:
 ${form.intent}
 
 Ekstra informasjon:
@@ -81,7 +81,7 @@ export const sendEmail = async (pdf: string, formData: IState): Promise<boolean>
         to: DESTINATION_EMAIL,
         cc: form.email,
         subject: `[${form.committee.shortName}] ${form.intent} - ${form.fullname}`,
-        text: getformattedText(form),
+        text: getFormattedText(form),
         attachments: [
           {
             filename: `[${getCurrentDateString()}]-${form.intent}-${form.amount}-kvitteringsskjema.pdf`,

--- a/src/lambda/tools/embed.ts
+++ b/src/lambda/tools/embed.ts
@@ -18,7 +18,7 @@ export const embedText = (form: NonNullableState, outputPDF: PDFDocument, page: 
     drawText(form.intent, positionText(165, 483)),
     drawText(form.type === 'deposit' ? 'X' : '', positionText(392, 483)),
     drawText(form.type === 'card' ? 'X' : '', positionText(392, 466)),
-    drawLinesOfText(createMultiLine(form.comments), positionText(165, 440))
+    drawLinesOfText(createMultiLine(form.comments || ''), positionText(165, 440))
   );
 
   page.addContentStreams(outputPDF.register(formContentStream));

--- a/src/models/comittees.ts
+++ b/src/models/comittees.ts
@@ -106,4 +106,10 @@ export const COMMITTEES: ICommittee[] = [
     name: 'Onlinepotten',
     email: 'hovedstyret@online.ntnu.no',
   },
+  {
+    shortName: 'Fondstyret',
+    group: 'Fond',
+    name: 'Fondstyret',
+    email: 'fond@online.ntnu.no',
+  },
 ];


### PR DESCRIPTION
- Set file size warning to 7 MB and error to 9 MB. to account for Fiken max size.
- Add 'kr' to formatting of mail text.
- Account both signature and attachments when validating file size.
- Dirty hack to resolve #60 